### PR TITLE
KeyUsage requirements for the delegation certificate

### DIFF
--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -336,7 +336,7 @@ complexity to the TLS stack).
 
 ## Certificate Requirements
 
-We define a new X.509 extension, DelegationUsage to be used in the certificate
+We define a new X.509 extension, DelegationUsage, to be used in the certificate
 when the certificate permits the usage of delegated credentials.
 
 ~~~~~~~~~~
@@ -349,7 +349,12 @@ certificate to be used by service owners for clients that do not support
 certificate delegation as well and not need to obtain two certificates.
 
 The client MUST NOT accept a delegated credential unless the server's end-entity
-certificate has the DelegationUsage extension.
+certificate satisfies the following criteria:
+
+* It has the DelegationUsage extension.
+* It has the digitalSignature key usage enabled (see the Keyusage type in
+  {{RFC5280}}), but has the keyEncipherment and dataEncipherment usages are
+  disabled.
 
 # IANA Considerations
 

--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -253,10 +253,10 @@ steps:
 
 * Verify that the current time is within the validity interval of the credential
   and that the credential's time to live is no more than 7 days.
-* Verify that the certificate has the DelegationUsage extension, which permits
-  the use of delegated credentials.
+* Verify that the end-entity certificate satisfies the conditions specified in
+  Section {{certificate-requirements}}.
 * Use the public key in the server's end-entity certificate to verify the
-  signature on the credential.
+  signature of the credential.
 
 If one or more of these checks fail, then the delegated credential is deemed
 invalid.  Clients that receive invalid delegated credentials MUST terminate the

--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -212,11 +212,11 @@ within an operator network.
 This document defines the following extension code point.
 
 ~~~~~~~~~~
-    enum {
-      ...
-      delegated_credential(TBD),
-      (65535)
-    } ExtensionType;
+   enum {
+     ...
+     delegated_credential(TBD),
+     (65535)
+   } ExtensionType;
 ~~~~~~~~~~
 
 A client which supports this document SHALL send an empty
@@ -275,16 +275,16 @@ objects as long as the certificate contains the digitalSignature key usage
 encode only the semantics that are needed for this application.
 
 ~~~~~~~~~~
-struct {
-  uint32 valid_time;
-  opaque public_key<0..2^16-1>;
-} Credential;
+   struct {
+     uint32 valid_time;
+     opaque public_key<0..2^16-1>;
+   } Credential;
 
-struct {
-  Credential cred;
-  SignatureScheme scheme;
-  opaque signature<0..2^16-1>;
-} DelegatedCredential;
+   struct {
+     Credential cred;
+     SignatureScheme scheme;
+     opaque signature<0..2^16-1>;
+   } DelegatedCredential;
 ~~~~~~~~~~
 
 valid_time:
@@ -337,19 +337,19 @@ complexity to the TLS stack).
 ## Certificate Requirements
 
 We define a new X.509 extension, DelegationUsage to be used in the certificate
-when the certificate permits the usage of delegated credentials.  When this
-extension is not present the client MUST not accept a delegated credential even
-if it is negotiated by the server.  When it is present, the client MUST follow
-the validation procedure.
+when the certificate permits the usage of delegated credentials.
 
-  id-ce-delegationUsage OBJECT IDENTIFIER ::=  { TBD }
-
-  DelegationUsage ::= BIT STRING { allowed (0) }
+~~~~~~~~~~
+   id-ce-delegationUsage OBJECT IDENTIFIER ::=  { TBD }
+   DelegationUsage ::= BIT STRING { allowed (0) }
+~~~~~~~~~~
 
 Conforming CAs MUST mark this extension as non-critical. This allows the
 certificate to be used by service owners for clients that do not support
 certificate delegation as well and not need to obtain two certificates.
 
+The client MUST NOT accept a delegated credential unless the server's end-entity
+certificate has the DelegationUsage extension.
 
 # IANA Considerations
 


### PR DESCRIPTION
Based on #5 

One of the design criteria for this standard is to isolate the TLS with the DC extension from other protocols. In this PR, I propose explicitly restricting the X.509 KeyUsage of the end-entity certificate.

This change is made in the last commit: https://github.com/tlswg/tls-subcerts/commit/9bb99f847c41e66420878e551c2df2170a36d29c. The two commits that proceed it don't actually change the semantics of the standard, but clean up the language a bit. If the KeyUsage change isn't adopted, we might consider merging the other two commits.