### PR TITLE
Tighter binding to handshake parameters

### DIFF
--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -336,7 +336,7 @@ complexity to the TLS stack).
 
 ## Certificate Requirements
 
-We define a new X.509 extension, DelegationUsage to be used in the certificate
+We define a new X.509 extension, DelegationUsage, to be used in the certificate
 when the certificate permits the usage of delegated credentials.
 
 ~~~~~~~~~~
@@ -349,7 +349,12 @@ certificate to be used by service owners for clients that do not support
 certificate delegation as well and not need to obtain two certificates.
 
 The client MUST NOT accept a delegated credential unless the server's end-entity
-certificate has the DelegationUsage extension.
+certificate satisfies the following criteria:
+
+* It has the DelegationUsage extension.
+* It has the digitalSignature key usage enabled (see the Keyusage type in
+  {{RFC5280}}), but has the keyEncipherment and dataEncipherment usages are
+  disabled.
 
 # IANA Considerations
 

--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -253,10 +253,10 @@ steps:
 
 * Verify that the current time is within the validity interval of the credential
   and that the credential's time to live is no more than 7 days.
-* Verify that the certificate has the DelegationUsage extension, which permits
-  the use of delegated credentials.
+* Verify that the end-entity certificate satisfies the conditions specified in
+  Section {{certificate-requirements}}.
 * Use the public key in the server's end-entity certificate to verify the
-  signature on the credential.
+  signature of the credential.
 
 If one or more of these checks fail, then the delegated credential is deemed
 invalid.  Clients that receive invalid delegated credentials MUST terminate the

--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -212,11 +212,11 @@ within an operator network.
 This document defines the following extension code point.
 
 ~~~~~~~~~~
-    enum {
-      ...
-      delegated_credential(TBD),
-      (65535)
-    } ExtensionType;
+   enum {
+     ...
+     delegated_credential(TBD),
+     (65535)
+   } ExtensionType;
 ~~~~~~~~~~
 
 A client which supports this document SHALL send an empty
@@ -275,16 +275,16 @@ objects as long as the certificate contains the digitalSignature key usage
 encode only the semantics that are needed for this application.
 
 ~~~~~~~~~~
-struct {
-  uint32 valid_time;
-  opaque public_key<0..2^16-1>;
-} Credential;
+   struct {
+     uint32 valid_time;
+     opaque public_key<0..2^16-1>;
+   } Credential;
 
-struct {
-  Credential cred;
-  SignatureScheme scheme;
-  opaque signature<0..2^16-1>;
-} DelegatedCredential;
+   struct {
+     Credential cred;
+     SignatureScheme scheme;
+     opaque signature<0..2^16-1>;
+   } DelegatedCredential;
 ~~~~~~~~~~
 
 valid_time:
@@ -337,19 +337,19 @@ complexity to the TLS stack).
 ## Certificate Requirements
 
 We define a new X.509 extension, DelegationUsage to be used in the certificate
-when the certificate permits the usage of delegated credentials.  When this
-extension is not present the client MUST not accept a delegated credential even
-if it is negotiated by the server.  When it is present, the client MUST follow
-the validation procedure.
+when the certificate permits the usage of delegated credentials.
 
-  id-ce-delegationUsage OBJECT IDENTIFIER ::=  { TBD }
-
-  DelegationUsage ::= BIT STRING { allowed (0) }
+~~~~~~~~~~
+   id-ce-delegationUsage OBJECT IDENTIFIER ::=  { TBD }
+   DelegationUsage ::= BIT STRING { allowed (0) }
+~~~~~~~~~~
 
 Conforming CAs MUST mark this extension as non-critical. This allows the
 certificate to be used by service owners for clients that do not support
 certificate delegation as well and not need to obtain two certificates.
 
+The client MUST NOT accept a delegated credential unless the server's end-entity
+certificate has the DelegationUsage extension.
 
 # IANA Considerations
 

--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -82,26 +82,23 @@ on an external CA for such short-lived credentials. In OCSP stapling, if an
 operator chooses to talk frequently to the CA to obtain stapled responses, then
 failure to fetch an OCSP stapled response results only in degraded performance.
 On the other hand, failure to fetch a potentially large number of short lived
-certificates would result in the service not being available which creates
+certificates would result in the service not being available, which creates
 greater operational risk.
 
 To remove these dependencies, this document proposes a limited delegation
 mechanism that allows a TLS server operator to issue its own credentials within
 the scope of a certificate issued by an external CA.  Because the above
-problems do not relate to the CAs inherent function of validating possession of
+problems do not relate to the CA's inherent function of validating possession of
 names, it is safe to make such delegations as long as they only enable the
 recipient of the delegation to speak for names that the CA has authorized.  For
-clarity, we will refer to the certificate issued by the CA as a "certificate"
-and the one issued by the operator as a "delegated credential".
+clarity, we will refer to the certificate issued by the CA as a "certificate",
+or "deleagation certificate", and the one issued by the operator as a "delegated
+credential".
 
 # Solution Overview
 
-A delegated credential is a digitally signed data structure with the following
-semantic fields:
-
-* A validity interval
-* A public key (with its associated algorithm)
-
+A delegated credential is a digitally signed data structure with two semantic
+fields: a validity interval, and a public key (with its associated algorithm).
 The signature on the credential indicates a delegation from the certificate that
 is issued to the TLS server operator. The secret key used to sign a credential
 is presumed to be one whose corresponding public key is contained in an X.509
@@ -131,10 +128,10 @@ new DelegationUsage extension to X.509 that permits use of delegated
 credentials.  Clients MUST NOT accept delegated credentials associated with
 certificates without this extension.
 
-Credentials allow the server to terminate TLS connections on behalf of the
-certificate owner.  If a credential is stolen, there is no mechanism for
-revoking it without revoking the certificate itself.  To limit the exposure of
-a delegation credential compromise, servers MUST NOT issue credentials with a
+Delegated credentials allow the server to terminate TLS connections on behalf of
+the certificate owner.  If a credential is stolen, there is no mechanism for
+revoking it without revoking the certificate itself.  To limit the exposure of a
+delegation credential compromise, servers MUST NOT issue credentials with a
 validity period longer than 7 days.  Clients MUST NOT accept credentials with
 longer validity periods.
 
@@ -146,9 +143,8 @@ mechanisms like proxy certificates {{RFC3820}} for several reasons:
 * There is no change needed to certificate validation at the PKI layer.
 * X.509 semantics are very rich.  This can cause unintended consequences if a
   service owner creates a proxy cert where the properties differ from the leaf
-  certificate.
-* Delegated credentials have very restricted semantics which should not
-  conflict with X.509 semantics.
+  certificate. For this reason, delegated credentials have very restricted
+  semantics which should not conflict with X.509 semantics.
 * Proxy certificates rely on the certificate path building process to establish
   a binding between the proxy certificate and the server certificate.  Since
   the cert path building process is not cryptographically protected, it is
@@ -187,7 +183,7 @@ Client            Front-End            Back-End
 Delegated credentials:
 
 Client            Front-End            Back-End
-  |                   |<--Cred Provision-->|
+  |                   |<----DC minting---->|
   |----ClientHello--->|                    |
   |<---ServerHello----|                    |
   |<---Certificate----|                    |

--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -246,10 +246,11 @@ the credential's public key is not usable with the supported signature
 algorithms of the client, even if the client advertises support for delegated
 credentials.
 
-On receiving a credential and a certificate chain, the client validates the
-certificate chain and matches the end-entity certificate to the server's
-expected identity following its normal procedures. It then takes the following
-steps:
+The SignatureScheme the server selects in the "signature_algorithms" extension
+MUST be that of the credential public key.  On receiving a credential and a
+certificate chain, the client validates the certificate chain and matches the
+end-entity certificate to the server's expected identity following its normal
+procedures. It then takes the following steps:
 
 * Verify that the current time is within the validity interval of the credential
   and that the credential's time to live is no more than 7 days.
@@ -299,7 +300,8 @@ public_key:
 
 scheme:
 
-: The signature algorithm used to sign the delegated credential.
+: The signature algorithm used to sign the delegated credential, where
+  SignatureScheme is as defined in the TLS 1.3 standard.
 
 signature:
 
@@ -315,18 +317,21 @@ The signature of the DelegatedCredential is computed over the concatenation of:
 
 1. A string that consists of octet 32 (0x20) repeated 64 times.
 2. The context string "TLS, server delegated credentials".
-3. A single 0 byte which serves as the separator.
-4. Big endian serialized 2 bytes ProtocolVersion of the negotiated TLS version,
-   defined by TLS.
-5. DER encoded X.509 certificate used to sign the DelegatedCredential.
-6. Big endian serialized 2 byte SignatureScheme scheme.
-7. The Credential structure.
+3. A single 0 byte, which serves as the separator.
+4. The DER-encoded X.509 end-entity certificate used to sign the
+   DelegatedCredential.
+5. The ProtocolVersion in which the delegated credential is to be used, where
+   ProtocolVersion is as defined in the TLS 1.3 standard.
+6. The SignatureScheme of Credential.public_key, the signature scheme used by
+   the server to sign the handshake.
+7. DelegatedCredential.scheme.
+8. DelegatedCredential.cred.
 
-This signature has a few desirable properties:
-
-* It is bound to the certificate that signed it.
-* It is bound to the protocol version that is negotiated.  This is intended to
-  avoid cross-protocol attacks with signing oracles.
+The signature effectively binds the credential to the parameters of the
+handshake in which it is used. In particular, it ensures that credentials are
+only used with the certificate, protocol, and signature algorithm chosen by the
+delegator.  Minimizing their semantics in this way is intended to mitigate thee
+risk of cross protocol attacks involving delegated credentials.
 
 The code changes to create and verify delegated credentials would be localized
 to the TLS stack, which has the advantage of avoiding changes to


### PR DESCRIPTION
Based on #6 

There is currently no binding of the credential to the signature scheme used to sign the handshake. The `AlgorithmIdentifier` field of the `SubjectPublicKeyInfo` encodes the DC public key type; but there's not a one-to-one correspondence between X.509's `AlgorithmIdentifier` and TLS `SignatureScheme`. Hence, the TLS terminator could use a signature scheme to sign the handshake other than the scheme intended by the delegator.

To prevent this, this PR adds the SignatureScheme that the TLS terminator selects in the "signature_algorithms" extension to scope of the delegation signature. In addition, it makes this and the protocol version explicit parameters of the Credential structure. This is intended to make debugging easier.