### PR TITLE
Draft 2

### DIFF
--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -174,7 +174,7 @@ mechanisms like proxy certificates {{RFC3820}} for several reasons:
   the same public key, with different X.509 parameters.  Delegated credentials,
   which rely on a cryptographic binding between the entire certificate and the
   delegated credential, cannot.
-* Delegated credentials are bound to specific versions of TLS and signature
+* Each delegated credential is bound to a specific version of TLS and signature
   algorithm.  This prevents them from being used for other protocols or with
   other signature algorithms than service owner allows.
 
@@ -230,7 +230,7 @@ within an operator network.
 
 While X.509 forbids end-entity certificates from being used as issuers for
 other certificates, it is perfectly fine to use them to issue other signed
-objects as long as the certificate contains the digitalSignature key usage
+objects as long as the certificate contains the digitalSignature KeyUsage
 (RFC5280 section 4.2.1.3).  We define a new signed object format that would
 encode only the semantics that are needed for this application.  The credential
 has the following structure:
@@ -298,7 +298,7 @@ The signature of the DelegatedCredential is computed over the concatenation of:
 The signature effectively binds the credential to the parameters of the
 handshake in which it is used.  In particular, it ensures that credentials are
 only used with the certificate, protocol, and signature algorithm chosen by the
-delegator.  Minimizing their semantics in this way is intended to mitigate thee
+delegator.  Minimizing their semantics in this way is intended to mitigate the
 risk of cross protocol attacks involving delegated credentials.
 
 The code changes to create and verify delegated credentials would be localized
@@ -323,31 +323,31 @@ A client which supports this specification SHALL send an empty
 delegated credential without indicating support, then the client MUST abort with
 an "unexpected_message" alert.
 
-If the extension is present, the server MAY send a delegated credential
-extension; if the extension is not present, the server MUST NOT send a delegated
-credential.  A delegated credential MUST NOT be provided unless a Certificate
-message is also sent.  The server MUST ignore the extension unless TLS 1.3 or
-a later version is negotiated.
+If the extension is present, the server MAY send a delegated credential; if the
+extension is not present, the server MUST NOT send a delegated credential.  A
+delegated credential MUST NOT be provided unless a Certificate message is also
+sent.  The server MUST ignore the extension unless TLS 1.3 or a later version is
+negotiated.
 
 The server MUST send the delegated credential as an extension in the
 CertificateEntry of its end-entity certificate; the client SHOULD ignore
 delegated credentials sent as extensions to any other certificate.
 
-The DelegatedCredential.scheme and Credential.scheme fields MUST be of a type
+The algorithm and expected_cert_verify_algorithm fields MUST be of a type
 advertised by the client in the "signature_algorithms" extension.  A delegated
 credential MUST NOT be negotiated otherwise, even if the client advertises
 support for delegated credentials.
 
 On receiving a delegated credential and a certificate chain, the client
 validates the certificate chain and matches the end-entity certificate to the
-server's expected identity following its normal procedures.  It then takes the
+server's expected identity following its normal procedures.  It also takes the
 following steps:
 
 1. Verify that the current time is within the validity interval of the credential
    and that the credential's time to live is no more than 7 days.
-2. Verify that DelegatedCredential.cred.expected_cert_verify_algorithm matches
+2. Verify that expected_cert_verify_algorithm matches
    the scheme indicated in the server's CertificateVerify message.
-3. Verify that DelegatedCredential.cred.expected_version matches the protocol
+3. Verify that expected_version matches the protocol
    version indicated in the server's "supported_versions" extension.
 4. Verify that the end-entity certificate satisfies the conditions specified in
    {{certificate-requirements}}.
@@ -376,7 +376,7 @@ The client MUST NOT accept a delegated credential unless the server's end-entity
 certificate satisfies the following criteria:
 
 * It has the DelegationUsage extension.
-* It has the digitalSignature key usage enabled (see the Keyusage type in
+* It has the digitalSignature KeyUsage (see the KeyUsage extension defined in
   {{RFC5280}}).
 
 

--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -53,15 +53,16 @@ informative:
 --- abstract
 
 The organizational separation between the operator of a TLS server and the
-certificate authority that provides it credentials can cause problems, for
-example when it comes to reducing the lifetime of certificates or supporting
-new cryptographic algorithms.  This document describes a mechanism to allow TLS
-server operators to create their own credential delegations without breaking
-compatibility with clients that do not support this specification.
+certificate authority restricts the operator in ways not necessarily envisioned
+in this design.  For example, the lifetime of certificates, how they may be used,
+and the algorithms they support are ultimately determined by the certificate
+authority.  This document describes a mechanism by which operators may delegate
+their own credentials for use in TLS, without breaking compatibility with
+clients that do not support this specification.
 
 --- middle
 
-#Introduction
+# Introduction
 
 Typically, a TLS server uses a certificate provided by some entity other than
 the operator of the server (a "Certification Authority" or CA) {{!RFC5246}}
@@ -78,7 +79,7 @@ create short-lived certificates for servers in low-trust zones such as CDNs or
 remote data centers.  This allows server operators to limit the exposure of keys
 in cases that they do not realize a compromise has occurred.  The risk inherent
 in cross-organizational transactions makes it operationally infeasible to rely
-on an external CA for such short-lived credentials. In OCSP stapling, if an
+on an external CA for such short-lived credentials.  In OCSP stapling, if an
 operator chooses to talk frequently to the CA to obtain stapled responses, then
 failure to fetch an OCSP stapled response results only in degraded performance.
 On the other hand, failure to fetch a potentially large number of short lived
@@ -98,11 +99,12 @@ credential".
 # Solution Overview
 
 A delegated credential is a digitally signed data structure with two semantic
-fields: a validity interval, and a public key (with its associated algorithm).
-The signature on the credential indicates a delegation from the certificate that
-is issued to the TLS server operator. The secret key used to sign a credential
-is presumed to be one whose corresponding public key is contained in an X.509
-certificate that associates one or more names to the credential.
+fields: a validity interval and a public key (along with its associated
+algorithm).  The signature on the credential indicates a delegation from the
+certificate that is issued to the TLS server operator.  The secret key used to
+sign a credential is presumed to be one whose corresponding public key is
+contained in an X.509 certificate that associates one or more names to the
+credential.
 
 A TLS handshake that uses credentials differs from a normal handshake in a few
 important ways:
@@ -110,30 +112,32 @@ important ways:
 * The client provides an extension in its ClientHello that indicates support
   for this mechanism.
 * The server provides both the certificate chain terminating in its certificate
-  as well as the credential.
+  as well as the delegated credential.
 * The client uses information in the server's certificate to verify the
-  signature on the credential and verify that the server is asserting an
-  expected identity.
+  delegation and that the server is asserting an expected identity.
 * The client uses the public key in the credential as the server's
   working key for the TLS handshake.
 
-This document specifies the use of delegated credentials in TLS 1.3 or later;
-their use in prior versions of the protocol is explicitly disallowed.
-
-It was noted in [XPROT] that certificates in use by servers that support
-outdated protocols such as SSLv2 can be used to forge signatures for
-certificates that contain the keyEncipherment KeyUsage ({{!RFC5280}} section
-4.2.1.3) In order to prevent this type of cross-protocol attack, we define a
-new DelegationUsage extension to X.509 that permits use of delegated
-credentials.  Clients MUST NOT accept delegated credentials associated with
-certificates without this extension.
+As detailed in {{delegated-credentials}}, the delegated credential is
+cryptographically bound to delegation certificate and the protocol in which the
+credential may be used.  This document specifies the use of delegated credentials
+in TLS 1.3 or later; their use in prior versions of the protocol is explicitly
+disallowed.
 
 Delegated credentials allow the server to terminate TLS connections on behalf of
 the certificate owner.  If a credential is stolen, there is no mechanism for
 revoking it without revoking the certificate itself.  To limit the exposure of a
-delegation credential compromise, servers MUST NOT issue credentials with a
-validity period longer than 7 days.  Clients MUST NOT accept credentials with
-longer validity periods.
+delegation credential compromise, servers may not issue credentials with a
+validity period longer than 7 days.  This mechanism is described in detail in
+{{client-and-server-behavior}}.
+
+It was noted in [XPROT] that certificates in use by servers that support
+outdated protocols such as SSLv2 can be used to forge signatures for
+certificates that contain the keyEncipherment KeyUsage ({{!RFC5280}} section
+4.2.1.3)  In order to prevent this type of cross-protocol attack, we define a
+new DelegationUsage extension to X.509 that permits use of delegated
+credentials.  The certificate's KeyUsage is restricted in other ways, as
+described in {{certificate-requirements}}.
 
 ## Rationale
 
@@ -142,17 +146,17 @@ mechanisms like proxy certificates {{RFC3820}} for several reasons:
 
 * There is no change needed to certificate validation at the PKI layer.
 * X.509 semantics are very rich.  This can cause unintended consequences if a
-  service owner creates a proxy cert where the properties differ from the leaf
-  certificate. For this reason, delegated credentials have very restricted
+  service owner creates a proxy certificate where the properties differ from the leaf
+  certificate.  For this reason, delegated credentials have very restricted
   semantics which should not conflict with X.509 semantics.
 * Proxy certificates rely on the certificate path building process to establish
   a binding between the proxy certificate and the server certificate.  Since
-  the cert path building process is not cryptographically protected, it is
+  the certificate path building process is not cryptographically protected, it is
   possible that a proxy certificate could be bound to another certificate with
   the same public key, with different X.509 parameters.  Delegated credentials,
   which rely on a cryptographic binding between the entire certificate and the
   delegated credential, cannot.
-* Delegated credentials are bound to specific versions of TLS. This prevents
+* Delegated credentials are bound to specific versions of TLS.  This prevents
   them from being used for other protocols if a service owner allows multiple
   versions of TLS.
 
@@ -188,6 +192,7 @@ Client            Front-End            Back-End
   |<---ServerHello----|                    |
   |<---Certificate----|                    |
   |<---CertVerify-----|                    |
+  |        ...        |                    |
 ~~~~~~~~~~
 
 These two mechanisms can be complementary.  A server could use credentials for
@@ -203,70 +208,13 @@ automated issuance APIs like ACME may be useful for provisioning credentials,
 within an operator network.
 
 
-# Client and Server behavior
-
-This document defines the following extension code point.
-
-~~~~~~~~~~
-   enum {
-     ...
-     delegated_credential(TBD),
-     (65535)
-   } ExtensionType;
-~~~~~~~~~~
-
-A client which supports this document SHALL send an empty
-"delegated_credential" extension in its ClientHello.  If the client receives a
-delegated credential without indicating support, then the client MUST abort with
-an "unexpected_message" alert.
-
-If the extension is present, the server MAY send a delegated credential
-extension; if the extension is not present, the server MUST NOT send a delegated
-credential.  A delegated credential MUST NOT be provided unless a Certificate
-message is also sent. The server MUST ignore the extension unless TLS 1.3 or
-later is negotiated.
-
-The server MUST send the delegated credential as an extension in the
-CertificateEntry of its end-entity certificate; the client SHOULD ignore
-delegated credentials sent as extensions to any other certificate.
-
-The delegated credential contains a signature from the public key in the
-end-entity certificate using a signature algorithm advertised by the client in
-the "signature_algorithms" extension. Additionally, the credential's public
-key MUST be of a type that enables at least one of the supported signature
-algorithms. A delegated credential MUST NOT be negotiated by the server if its
-signature is not compatible with any of the supported signature algorithms or
-the credential's public key is not usable with the supported signature
-algorithms of the client, even if the client advertises support for delegated
-credentials.
-
-The SignatureScheme the server selects in the "signature_algorithms" extension
-MUST be that of the credential public key.  On receiving a credential and a
-certificate chain, the client validates the certificate chain and matches the
-end-entity certificate to the server's expected identity following its normal
-procedures. It then takes the following steps:
-
-* Verify that the current time is within the validity interval of the credential
-  and that the credential's time to live is no more than 7 days.
-* Verify that the end-entity certificate satisfies the conditions specified in
-  Section {{certificate-requirements}}.
-* Use the public key in the server's end-entity certificate to verify the
-  signature of the credential.
-
-If one or more of these checks fail, then the delegated credential is deemed
-invalid.  Clients that receive invalid delegated credentials MUST terminate the
-connection with an "illegal_parameter" alert. If successful, the client uses the
-public key in the credential to verify the signature in the serer's
-CertificateVerify message.
-
-
 # Delegated Credentials
 
 While X.509 forbids end-entity certificates from being used as issuers for
 other certificates, it is perfectly fine to use them to issue other signed
 objects as long as the certificate contains the digitalSignature key usage
 (RFC5280 section 4.2.1.3).  We define a new signed object format that would
-encode only the semantics that are needed for this application. The credential
+encode only the semantics that are needed for this application.  The credential
 has the following structure:
 
 ~~~~~~~~~~
@@ -295,8 +243,8 @@ version:
 
 public_key:
 
-: The delegated credential's public key, which is an encoded
-  SubjectPublicKeyInfo {{!RFC5280}}.
+: The credential's public key, a DER-encoded SubjectPublicKeyInfo as defined in
+{{!RFC5280}}.
 
 The delegated credential has the following structure:
 
@@ -310,8 +258,7 @@ The delegated credential has the following structure:
 
 scheme:
 
-: The signature algorithm used to sign the delegated credential, where
-  SignatureScheme is as defined in the TLS 1.3 standard.
+: The signature algorithm used to sign the delegated credential.
 
 signature:
 
@@ -329,7 +276,7 @@ The signature of the DelegatedCredential is computed over the concatenation of:
 6. DelegatedCredential.scheme.
 
 The signature effectively binds the credential to the parameters of the
-handshake in which it is used. In particular, it ensures that credentials are
+handshake in which it is used.  In particular, it ensures that credentials are
 only used with the certificate, protocol, and signature algorithm chosen by the
 delegator.  Minimizing their semantics in this way is intended to mitigate thee
 risk of cross protocol attacks involving delegated credentials.
@@ -338,6 +285,57 @@ The code changes to create and verify delegated credentials would be localized
 to the TLS stack, which has the advantage of avoiding changes to
 security-critical and often delicate PKI code (though of course moves that
 complexity to the TLS stack).
+
+## Client and Server behavior
+
+This document defines the following extension code point.
+
+~~~~~~~~~~
+   enum {
+     ...
+     delegated_credential(TBD),
+     (65535)
+   } ExtensionType;
+~~~~~~~~~~
+
+A client which supports this specification SHALL send an empty
+"delegated_credential" extension in its ClientHello.  If the client receives a
+delegated credential without indicating support, then the client MUST abort with
+an "unexpected_message" alert.
+
+If the extension is present, the server MAY send a delegated credential
+extension; if the extension is not present, the server MUST NOT send a delegated
+credential.  A delegated credential MUST NOT be provided unless a Certificate
+message is also sent.  The server MUST ignore the extension unless TLS 1.3 or
+later is negotiated.
+
+The server MUST send the delegated credential as an extension in the
+CertificateEntry of its end-entity certificate; the client SHOULD ignore
+delegated credentials sent as extensions to any other certificate.
+
+The DelegatedCredential.scheme and Credential.scheme fields MUST be of a type
+advertised by the client in the "signature_algorithms" extension.  A delegated
+credential MUST NOT be negotiated otherwise, even if the client advertises
+support for delegated credentials.  The SignatureScheme the server selects in the
+"signature_algorithms" extension MUST be that of the credential public key.
+
+On receiving a delegated credential and a certificate chain, the client
+validates the certificate chain and matches the end-entity certificate to the
+server's expected identity following its normal procedures.  It then takes the
+following steps:
+
+* Verify that the current time is within the validity interval of the credential
+  and that the credential's time to live is no more than 7 days.
+* Verify that the end-entity certificate satisfies the conditions specified in
+  Section {{certificate-requirements}}.
+* Use the public key in the server's end-entity certificate to verify the
+  signature of the credential.
+
+If one or more of these checks fail, then the delegated credential is deemed
+invalid.  Clients that receive invalid delegated credentials MUST terminate the
+connection with an "illegal_parameter" alert.  If successful, the client uses the
+public key in the credential to verify the signature in the server's
+CertificateVerify message.
 
 ## Certificate Requirements
 
@@ -357,7 +355,7 @@ certificate satisfies the following criteria:
   {{RFC5280}}), but has the keyEncipherment and dataEncipherment usages are
   disabled.
 
-The extension MAY be marked crititcal. (See Section 4.2 of {{RFC5280}}.) If the
+The extension MAY be marked critical.  (See Section 4.2 of {{RFC5280}}.)  If the
 strict boolean is set to true, then the server MUST use delegated credential in
 the handshake; if no delegated credential is offered, then the client MUST abort
 the handshake with an "illegal_parameter" alert.
@@ -373,9 +371,9 @@ TBD
 
 Marking the delegation certificate's DelegationUsage extension non-critical
 allows the certificate to be used for clients that do not support delegated
-credentials. However, it may be desirable to ensure that the delegation
+credentials.  However, it may be desirable to ensure that the delegation
 certificate is only used in handshakes in which a delegated credential
-negotiated. It suffices to mark the extension crticial and set the strict
+negotiated.  It suffices to mark the extension critical and set the strict
 boolean to true: if the client does not support delegated credentials, then it
 will abort the handshake if the certificate has the DelegationUsage extension
 (as per Section 4.2 of {{RFC5280}}); if the client indicates support, but the
@@ -387,7 +385,7 @@ handshake (as per {{certificate-requirements}}).
 Delegated credentials limit the exposure of the TLS private key by limiting
 its validity.  An attacker who compromises the private key of a delegated
 credential can act as a man in the middle until the delegate credential
-expires, however they cannot create new delegated credentials. Thus delegated
+expires, however they cannot create new delegated credentials.  Thus delegated
 credentials should not be used to send a delegation to an untrusted party, but
 is meant to be used between parties that have some trust relationship with each
 other.  The secrecy of the delegated private key is thus important and several
@@ -400,19 +398,19 @@ controls, physical security or hardware security modules.
 Delegated credentials do not provide any additional form of early revocation.
 Since it is short lived, the expiry of the delegated credential would revoke
 the credential.  Revocation of the long term private key that signs the
-delegated credential also implictly revokes the delegated credential.
+delegated credential also implicitly revokes the delegated credential.
 
 
 ## Privacy considerations
 
 Delegated credentials can be valid for 7 days and it is much easier for a
-service to create delegated credential than a certificate signed by a CA. A
+service to create delegated credential than a certificate signed by a CA.  A
 service could determine the client time and clock skew by creating several
-delegated credentials with different expiry timestamps and observing whether
-the client would accept it.  Client time could be unique and thus privacy
-sensitive clients, such as browsers in incognito mode, who do not trust the
-service might not want to advertise support for delegated credentials or limit
-the number of probes that a server can perform.
+delegated credentials with different expiry timestamps and observing whether the
+client would accept it.  Client time could be unique and thus privacy sensitive
+clients, such as browsers in incognito mode, who do not trust the service might
+not want to advertise support for delegated credentials or limit the number of
+probes that a server can perform.
 
 # Acknowledgements
 


### PR DESCRIPTION
Based on #12 

This adds a change log with changes from draft-01. It drops the proposed "must-use-DC" semantics from the X.509 extension. There doesn't seem to be a clean way to do this, and the complexity it adds seems to outweigh any potential benefit.

The changes are as follows:
* Change DelegationUsage extension type to NULL.
* Drop support for TLS 1.2.
* Add the protocol version and credential signature algorithm to the Credential structure. (*)
* Specify undefined behavior in a few cases: when the client receives a DC without indicated support; when the client indicates the extension in an invalid protocol version; and when DCs are sent as extensions to certificates other than the end-entity certificate.