### PR TITLE
Revise an introductory paragraph for greater clarity.

### DIFF
--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -103,7 +103,7 @@ These dependencies cause problems in practice.  Server operators often want to
 create short-lived certificates for servers in low-trust zones such as Content
 Delivery Networks (CDNs) or remote data centers.  This allows server operators
 to limit the exposure of keys in cases where they do not realize a compromise
-has occurred.  But the risk inherent in cross-organizational transactions makes it
+has occurred.  However, the risk inherent in cross-organizational transactions makes it
 operationally infeasible to rely on an external CA for such short-lived credentials.
 For instance, in the case of Online Certificate Status Protocol (OCSP) stapling
 (i.e., using the Certificate Status extension type ocsp {{?RFC8446}}), a CA may fail

--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -101,17 +101,17 @@ dependent on the CA for some aspects of its operations, for example:
 
 These dependencies cause problems in practice.  Server operators often want to
 create short-lived certificates for servers in low-trust zones such as Content
-Delivery Network (CDNs) or remote data centers.  This allows server operators
-to limit the exposure of keys in cases that they do not realize a compromise
-has occurred.  The risk inherent in cross-organizational transactions makes it
-operationally infeasible to rely on an external CA for such short-lived
-credentials.  In Online Certificate Status Protocol (OCSP) stapling (i.e., using
-the Certificate Status extension type ocsp {{?RFC8446}}, if an operator
-chooses to talk frequently to the CA to obtain
-stapled responses, then failure to fetch an OCSP stapled response results only
-in degraded performance.  On the other hand, failure to fetch a potentially
-large number of short lived certificates would result in the service not being
-available, which creates greater operational risk.
+Delivery Networks (CDNs) or remote data centers.  This allows server operators
+to limit the exposure of keys in cases where they do not realize a compromise
+has occurred.  But the risk inherent in cross-organizational transactions makes it
+operationally infeasible to rely on an external CA for such short-lived credentials.
+For instance, in the case of Online Certificate Status Protocol (OCSP) stapling
+(i.e., using the Certificate Status extension type ocsp {{?RFC8446}}), a CA may fail
+to deliver OCSP stapled response.  While this will result in degraded performance,
+the ramifications of failing to deliver short-lived certificates are even worse: the
+service that depends on those certificates would go down entirely.  Thus, ensuring
+independence from CAs for short-lived certificates is critical to the uptime of a
+service.
 
 To remove these dependencies, this document proposes a limited delegation
 mechanism that allows a TLS peer to issue its own credentials within


### PR DESCRIPTION
Also fixed a few smaller grammatical/punctuation errors.

Rationale from the mailing list:

- I think OCSP is being brought up here as an example of a way that dependence on a CA can go wrong, but that isn't really made explicit.

- I'm not sure what "only" means in "only in degraded performance." Is it "the worst that can happen is just degraded performance" or "it can result only in degraded performance, as opposed to better performance"? At first I thought it was the latter, but after reading the subsequent sentence, I realized it was probably the former.

- The use of "On the other hand" sounds like the rest of the sentence is going to describe a way that failure to receive something from a CA resulted in better performance, which obviously would be silly.