### PR TITLE
Correct text describing valid_time

### DIFF
--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -351,8 +351,8 @@ valid_time:
 
 : Time in seconds relative to the beginning of the delegation certificate's
   notBefore value after which the delegated credential is no longer valid.
-  Endpoints will reject delegate credentials with valid_times exceeding 7 days (as described
-  in {{client-and-server-behavior}}).
+  Endpoints will reject delegated credentials that expire more than 7 days
+  from the current time (as described in {{client-and-server-behavior}}).
 
 expected_cert_verify_algorithm:
 
@@ -487,18 +487,18 @@ delegated credentials MUST terminate the connection with an
 
 ### Validating a Delegated Credential
 
-On receiving a delegated credential and a certificate chain, the peer
-validates the certificate chain and matches the end-entity certificate to the
-peer's expected identity.  It also takes the following steps:
+On receiving a delegated credential and a certificate chain, the peer validates
+the certificate chain and matches the end-entity certificate to the peer's
+expected identity. Define `expiry time` as the delegation certificate's
+notBefore value plus DelegatedCredential.cred.valid_time. Then perform the
+following checks:
 
-1. Validate that DelegatedCredential.cred.valid_time is no more than 7 days.
-1. Verify that the current time is within the validity interval of the credential.
-   This is done by asserting that the current time is no more than the
-   delegation certificate's notBefore value plus DelegatedCredential.cred.valid_time.
-1. Verify that the delegated credential's remaining validity time is no more than the maximum validity
-   period. This is done by asserting that the current time is no more than the delegation
-   certificate's notBefore value plus DelegatedCredential.cred.valid_time plus
-   the maximum validity period.
+1. Verify that the current time is within the validity interval of the
+   credential. This is done by asserting that the current time does not exceed
+   the expiry time.
+1. Verify that the delegated credential's remaining validity period is no more
+   than the maximum validity period. This is done by asserting that the expiry
+   time does not exceed the current time plus the maximum validity period (7 days).
 1. Verify that expected_cert_verify_algorithm matches
    the scheme indicated in the peer's CertificateVerify message and that the
    algorithm is allowed for use with delegated credentials.

--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -489,9 +489,8 @@ delegated credentials MUST terminate the connection with an
 
 On receiving a delegated credential and a certificate chain, the peer validates
 the certificate chain and matches the end-entity certificate to the peer's
-expected identity. Define expiry time as the delegation certificate's
-notBefore value plus DelegatedCredential.cred.valid_time. Then perform the
-following checks:
+expected identity. It then performs the following checks with expiry time set to the 
+delegation certificate's notBefore value plus DelegatedCredential.cred.valid_time:
 
 1. Verify that the current time is within the validity interval of the
    credential. This is done by asserting that the current time does not exceed

--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -489,7 +489,7 @@ delegated credentials MUST terminate the connection with an
 
 On receiving a delegated credential and a certificate chain, the peer validates
 the certificate chain and matches the end-entity certificate to the peer's
-expected identity. Define `expiry time` as the delegation certificate's
+expected identity. Define expiry time as the delegation certificate's
 notBefore value plus DelegatedCredential.cred.valid_time. Then perform the
 following checks:
 


### PR DESCRIPTION
Update the condition for validating a DC to the following:

	now() <= notBefore + valid_time <= now() + 7d